### PR TITLE
Fix start after recommendSU

### DIFF
--- a/src/main/java/seedu/address/logic/commands/StartCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StartCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MODULES;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -45,6 +46,7 @@ public class StartCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
         SemesterManager semesterManager = SemesterManager.getInstance();
         semesterManager.setCurrentSemester(toStart);
         return new CommandResult(String.format(MESSAGE_START_SEMESTER_SUCCESS, toStart));


### PR DESCRIPTION
After running recommendSU, the module list in Model changes. So when start is called after recommendSU, the module list used is different, and the CAP changes.

Fixed by adding "model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);" in Start to refresh the module list aft running start.